### PR TITLE
Need support for secret-less usage #1

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,7 +1,7 @@
 Use the S3 plugin to upload files and build artifacts to an S3 bucket. The following parameters are used to configure this plugin:
 
-* **access_key** - amazon key
-* **secret_key** - amazon secret key
+* **access_key** - amazon key (optional)
+* **secret_key** - amazon secret key (optional)
 * **bucket** - bucket name
 * **region** - bucket region (`us-east-1`, `eu-west-1`, etc)
 * **acl** - access to files that are uploaded (`private`, `public-read`, etc)

--- a/main.go
+++ b/main.go
@@ -85,8 +85,12 @@ func main() {
 
 	cmd := command(vargs)
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, "AWS_ACCESS_KEY_ID="+vargs.Key)
-	cmd.Env = append(cmd.Env, "AWS_SECRET_ACCESS_KEY="+vargs.Secret)
+	if len(vargs.Key) > 0 {
+		cmd.Env = append(cmd.Env, "AWS_ACCESS_KEY_ID="+vargs.Key)
+	}
+	if len(vargs.Secret) > 0 {
+		cmd.Env = append(cmd.Env, "AWS_SECRET_ACCESS_KEY="+vargs.Secret)
+	}
 	cmd.Dir = workspace.Path
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Current implementation is rather limiting as there are more options
to how the bucket access can be configured (IAM role, credentials file
as a bound volume, environment variables through container's environment
file). Enforcing the only way and enforcing keeping .drone.sec is not
really necessary, IMO.

If credentials are insufficient, then the uploading will fail anyway. To
avoid uploads from forks/branches, I think, a more obvious solution should
be present.