### PR TITLE
Remove skipping if access_key/secret_key are empty

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -9,7 +9,7 @@ Use the S3 plugin to upload files and build artifacts to an S3 bucket. The follo
 * **target** - target location of files in your S3 bucket
 * **recursive** - if true, recursively upload files
 
-The following is a sample Slack configuration in your .drone.yml file:
+The following is a sample `s3` configuration in your .drone.yml file:
 
 ```yaml
 publish:

--- a/DOCS.md
+++ b/DOCS.md
@@ -2,6 +2,7 @@ Use the S3 plugin to upload files and build artifacts to an S3 bucket. The follo
 
 * **access_key** - amazon key (optional)
 * **secret_key** - amazon secret key (optional)
+* **use_iam** - use the host's AWS IAM role (optional)
 * **bucket** - bucket name
 * **region** - bucket region (`us-east-1`, `eu-west-1`, etc)
 * **acl** - access to files that are uploaded (`private`, `public-read`, etc)
@@ -9,7 +10,21 @@ Use the S3 plugin to upload files and build artifacts to an S3 bucket. The follo
 * **target** - target location of files in your S3 bucket
 * **recursive** - if true, recursively upload files
 
-The following is a sample `s3` configuration in your .drone.yml file:
+The following is a sample S3 configuration that will use the host's IAM role in your .drone.yml file:
+
+```yaml
+publish:
+  s3:
+    acl: public-read
+    region: "us-east-1"
+    bucket: "my-bucket-name"
+    use_iam: true
+    source: files/to/archive
+    target: /target/location
+    recursive: true
+```
+
+Or you can specify an access_key and secret_key:
 
 ```yaml
 publish:

--- a/main.go
+++ b/main.go
@@ -64,13 +64,6 @@ func main() {
 	plugin.Param("vargs", &vargs)
 	plugin.MustParse()
 
-	// skip if AWS key or SECRET are empty. A good example for this would
-	// be forks building a project. S3 might be configured in the source
-	// repo, but not in the fork
-	if len(vargs.Key) == 0 || len(vargs.Secret) == 0 {
-		return
-	}
-
 	// make sure a default region is set
 	if len(vargs.Region) == 0 {
 		vargs.Region = "us-east-1"

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 type S3 struct {
 	Key    string `json:"access_key"`
 	Secret string `json:"secret_key"`
+	UseIam bool   `json:"use_iam"`
 	Bucket string `json:"bucket"`
 
 	// us-east-1
@@ -63,6 +64,18 @@ func main() {
 	plugin.Param("workspace", &workspace)
 	plugin.Param("vargs", &vargs)
 	plugin.MustParse()
+
+	// make sure either (access_key and secret_key) OR (use_iam) is set
+	if (len(vargs.Key) == 0 || len(vargs.Secret) == 0) && !vargs.UseIam {
+		fmt.Printf("Must specify either `access_key` and `secret_key` OR `use_iam`\n")
+		return
+	}
+
+	// make it an error if all three are set
+	if len(vargs.Key) > 0 && len(vargs.Secret) > 0 && vargs.UseIam {
+		fmt.Printf("Specifying `access_key`, `secret_key`, and `use_iam` is ambiguous.\n")
+		os.Exit(1)
+	}
 
 	// make sure a default region is set
 	if len(vargs.Region) == 0 {


### PR DESCRIPTION
Projects should be careful about what they try to upload and use the more
generic `when: repo: owner/name` method instead.

Closes: https://github.com/drone-plugins/drone-s3/issues/11
