### PR TITLE
Simple support for different endpoints

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -3,6 +3,7 @@ Use the S3 plugin to upload files and build artifacts to an S3 bucket. The follo
 * **access_key** - amazon key (optional)
 * **secret_key** - amazon secret key (optional)
 * **bucket** - bucket name
+* **endpoint** - custom endpoint URL (optional, to use a S3 compatible non-Amazon service)
 * **region** - bucket region (`us-east-1`, `eu-west-1`, etc)
 * **acl** - access to files that are uploaded (`private`, `public-read`, etc)
 * **source** - location of files to upload

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ FROM gliderlabs/alpine:3.1
 RUN apk add --update \
 	python \
 	py-pip \
-	&& pip install awscli
+	&& pip install awscli \
+	&& aws configure set default.s3.signature_version s3v4
 ADD drone-s3 /bin/
 ENTRYPOINT ["/bin/drone-s3"]

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ type S3 struct {
 	Secret string `json:"secret_key"`
 	Bucket string `json:"bucket"`
 
+	Endpoint string `json:"endpoint"`
+
 	// us-east-1
 	// us-west-1
 	// us-west-2
@@ -136,6 +138,10 @@ func command(s S3) *exec.Cmd {
 	// above arguments.
 	if !s.Recursive {
 		args = append(args[:4], args[4+1:]...)
+	}
+
+	if len(s.Endpoint) > 0 {
+		args = append(args, "--endpoint-url", s.Endpoint)
 	}
 
 	for i := 0; i < len(s.Include); i++ {


### PR DESCRIPTION
Hello,

like @alexex I'm interested in using different S3-compatible object storage engines.

I've quickly hacked together this little PR, it adds support for a `endpoint` property stating the desired endpoint URL. If it is omitted, no endpoint is passed to `awscli` and it functions like before.
I've added a `default.s3.signature_version` setting, as the S3 server I've used (minio) only supports v4 signatures, and according to Amazon documentation, all their regions support v4.
So far i've only tested `minio` as object storage engine.

Regards,
Christian