### PR TITLE
Allow for the s3 plugin to use the ec2 instance auth

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -69,11 +69,6 @@ type Plugin struct {
 // Exec runs the plugin
 func (p *Plugin) Exec() error {
 	// create the client
-	if p.Key != "" && p.Secret != "" {
-		os.Setenv("AWS_ACCESS_KEY_ID", p.Key)
-		os.Setenv("AWS_SECRET_ACCESS_KEY", p.Secret)
-
-	}
 	client := s3.New(session.New(), &aws.Config{
 		Region:           aws.String(p.Region),
 		Endpoint:         &p.Endpoint,

--- a/plugin.go
+++ b/plugin.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/mattn/go-zglob"
@@ -70,8 +69,12 @@ type Plugin struct {
 // Exec runs the plugin
 func (p *Plugin) Exec() error {
 	// create the client
+	if p.Key != "" && p.Secret != "" {
+		os.Setenv("AWS_ACCESS_KEY_ID", p.Key)
+		os.Setenv("AWS_SECRET_ACCESS_KEY", p.Secret)
+
+	}
 	client := s3.New(session.New(), &aws.Config{
-		Credentials:      credentials.NewStaticCredentials(p.Key, p.Secret, ""),
 		Region:           aws.String(p.Region),
 		Endpoint:         &p.Endpoint,
 		DisableSSL:       aws.Bool(strings.HasPrefix(p.Endpoint, "http://")),


### PR DESCRIPTION
Changing to not setting the auth on the constructor if not key is provided. Using the Setenv (unless there's a better suggestion). This will allow using the ec2 perms to be used to upload to s3