### PR TITLE
Integrated an option to strip a prefix

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -8,6 +8,7 @@ Use the S3 plugin to upload files and build artifacts to an S3 bucket. The follo
 * **acl** - access to files that are uploaded (`private`, `public-read`, etc)
 * **source** - source location of the files, using a glob matching pattern
 * **target** - target location of files in the bucket
+* **strip_prefix** - strip the prefix from source path
 * **exclude** - glob exclusion patterns
 * **path_style** - whether path style URLs should be used (true for minio, false for aws)
 
@@ -23,6 +24,7 @@ publish:
     access_key: "970d28f4dd477bc184fbd10b376de753"
     secret_key: "9c5785d3ece6a9cdefa42eb99b58986f9095ff1c"
     source: public/**/*
+    strip_prefix: public/
     target: /target/location
     exclude:
       - **/*.xml

--- a/main.go
+++ b/main.go
@@ -62,6 +62,11 @@ func main() {
 			Usage:  "upload files to target folder",
 			EnvVar: "PLUGIN_TARGET",
 		},
+		cli.StringFlag{
+			Name:   "strip-prefix",
+			Usage:  "strip the prefix from the target",
+			EnvVar: "PLUGIN_STRIP_PREFIX",
+		},
 		cli.BoolFlag{
 			Name:   "recursive",
 			Usage:  "upload files recursively",
@@ -104,6 +109,7 @@ func run(c *cli.Context) error {
 		Access:       c.String("acl"),
 		Source:       c.String("source"),
 		Target:       c.String("target"),
+		StripPrefix:  c.String("strip-prefix"),
 		Recursive:    c.Bool("recursive"),
 		Exclude:      c.StringSlice("exclude"),
 		PathStyle:    c.Bool("path-style"),

--- a/plugin.go
+++ b/plugin.go
@@ -54,10 +54,13 @@ type Plugin struct {
 	Source string
 	Target string
 
+	// Strip the prefix from the target path
+	StripPrefix string
+
 	// Recursive uploads
 	Recursive bool
 
-	YamlVerified     bool
+	YamlVerified bool
 
 	// Exclude files matching this pattern.
 	Exclude []string
@@ -116,7 +119,7 @@ func (p *Plugin) Exec() error {
 			continue
 		}
 
-		target := filepath.Join(p.Target, match)
+		target := filepath.Join(p.Target, strings.TrimPrefix(match, p.StripPrefix))
 		if !strings.HasPrefix(target, "/") {
 			target = "/" + target
 		}


### PR DESCRIPTION
Until now it have not been possible to strip a prefix from the source
directory, so now you can as an example upload files from /public/images
to the target /images or even /subfolde/images.

Now we just need to add a delete flag for a syncronization and we can get rid of the `s3-sync` plugin within Drone >= 0.5.