### PR TITLE
Env file

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -17,6 +17,7 @@ The following parameters are used to configure the plugin:
 * **strip_prefix** - strip the prefix from source path
 * **exclude** - glob exclusion patterns
 * **path_style** - whether path style URLs should be used (true for minio, false for aws)
+* **env_file** - environment file from which to load environment variables
 
 The following secret values can be set to configure the plugin.
 

--- a/main.go
+++ b/main.go
@@ -97,8 +97,8 @@ func main() {
 			EnvVar: "DRONE_YAML_VERIFIED",
 		},
 		cli.StringFlag{
-			Name:  "env-file",
-			Usage: "source env file",
+			Name:   "env-file",
+			Usage:  "source env file",
 			EnvVar: "PLUGIN_ENV_FILE",
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
+			EnvVar: "PLUGIN_ENV_FILE",
 		},
 	}
 


### PR DESCRIPTION
This introduces the ability to pass in an `env_file` param, similar to [drone-docker](https://github.com/drone-plugins/drone-docker/blob/master/main.go#L16-L18). 