### PR TITLE
Remove references to recursive

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,11 +66,6 @@ func main() {
 			Usage:  "strip the prefix from the target",
 			EnvVar: "PLUGIN_STRIP_PREFIX",
 		},
-		cli.BoolFlag{
-			Name:   "recursive",
-			Usage:  "upload files recursively",
-			EnvVar: "PLUGIN_RECURSIVE",
-		},
 		cli.StringSliceFlag{
 			Name:   "exclude",
 			Usage:  "ignore files matching exclude pattern",
@@ -122,7 +117,6 @@ func run(c *cli.Context) error {
 		Source:       c.String("source"),
 		Target:       c.String("target"),
 		StripPrefix:  c.String("strip-prefix"),
-		Recursive:    c.Bool("recursive"),
 		Exclude:      c.StringSlice("exclude"),
 		Encryption:   c.String("encryption"),
 		PathStyle:    c.Bool("path-style"),

--- a/plugin.go
+++ b/plugin.go
@@ -63,9 +63,6 @@ type Plugin struct {
 	// Strip the prefix from the target path
 	StripPrefix string
 
-	// Recursive uploads
-	Recursive bool
-
 	YamlVerified bool
 
 	// Exclude files matching this pattern.


### PR DESCRIPTION
Since the switch to Drone 0.5 syntax and using S3 go SDKs rather than calling out to the AWS CLI the recursive option has actually been obsolete, this simply removes this dead code.

(The commit where this became obsolete is here: https://github.com/drone-plugins/drone-s3/commit/6c101e57efe308d4255254f1fc7e1cbb86e297f5 )
  