### PR TITLE
Remove deprecated signed yaml verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM centurylink/ca-certs
-ENV GODEBUG=netdns=go
+FROM golang:1.9-alpine
+WORKDIR /go/src/github.com/quintoandar/drone-s3
+ADD . .
+RUN GOOS=linux CGO_ENABLED=0 go build -o /bin/drone-s3 \
+    github.com/quintoandar/drone-s3
 
-ADD contrib/mime.types /etc/
-ADD release/linux/amd64/drone-s3 /bin/
+FROM scratch
+COPY --from=0 /bin/drone-s3 /bin/drone-s3
 ENTRYPOINT ["/bin/drone-s3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ADD . .
 RUN GOOS=linux CGO_ENABLED=0 go build -o /bin/drone-s3 \
     github.com/quintoandar/drone-s3
 
-FROM scratch
+FROM alpine:3.7
+RUN apk add --no-cache ca-certificates
 COPY --from=0 /bin/drone-s3 /bin/drone-s3
 ENTRYPOINT ["/bin/drone-s3"]

--- a/main.go
+++ b/main.go
@@ -86,11 +86,6 @@ func main() {
 			Usage:  "use path style for bucket paths",
 			EnvVar: "PLUGIN_PATH_STYLE",
 		},
-		cli.BoolTFlag{
-			Name:   "yaml-verified",
-			Usage:  "Ensure the yaml was signed",
-			EnvVar: "DRONE_YAML_VERIFIED",
-		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -108,20 +103,19 @@ func run(c *cli.Context) error {
 	}
 
 	plugin := Plugin{
-		Endpoint:     c.String("endpoint"),
-		Key:          c.String("access-key"),
-		Secret:       c.String("secret-key"),
-		Bucket:       c.String("bucket"),
-		Region:       c.String("region"),
-		Access:       c.String("acl"),
-		Source:       c.String("source"),
-		Target:       c.String("target"),
-		StripPrefix:  c.String("strip-prefix"),
-		Exclude:      c.StringSlice("exclude"),
-		Encryption:   c.String("encryption"),
-		PathStyle:    c.Bool("path-style"),
-		DryRun:       c.Bool("dry-run"),
-		YamlVerified: c.BoolT("yaml-verified"),
+		Endpoint:    c.String("endpoint"),
+		Key:         c.String("access-key"),
+		Secret:      c.String("secret-key"),
+		Bucket:      c.String("bucket"),
+		Region:      c.String("region"),
+		Access:      c.String("acl"),
+		Source:      c.String("source"),
+		Target:      c.String("target"),
+		StripPrefix: c.String("strip-prefix"),
+		Exclude:     c.StringSlice("exclude"),
+		Encryption:  c.String("encryption"),
+		PathStyle:   c.Bool("path-style"),
+		DryRun:      c.Bool("dry-run"),
 	}
 
 	return plugin.Exec()

--- a/main.go
+++ b/main.go
@@ -104,6 +104,12 @@ func main() {
 			EnvVar: "PLUGIN_CACHE_CONTROL",
 			Value:  &StringMapFlag{},
 		},
+		cli.GenericFlag{
+			Name:   "metadata",
+			Usage:  "additional metadata for uploads",
+			EnvVar: "PLUGIN_METADATA",
+			Value:  &DeepStringMapFlag{},
+		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -136,6 +142,7 @@ func run(c *cli.Context) error {
 		CacheControl:    c.Generic("cache-control").(*StringMapFlag).Get(),
 		ContentType:     c.Generic("content-type").(*StringMapFlag).Get(),
 		ContentEncoding: c.Generic("content-encoding").(*StringMapFlag).Get(),
+		Metadata:        c.Generic("metadata").(*DeepStringMapFlag).Get(),
 		DryRun:          c.Bool("dry-run"),
 	}
 

--- a/main.go
+++ b/main.go
@@ -86,6 +86,24 @@ func main() {
 			Usage:  "use path style for bucket paths",
 			EnvVar: "PLUGIN_PATH_STYLE",
 		},
+		cli.GenericFlag{
+			Name:   "content-type",
+			Usage:  "content-type settings for uploads",
+			EnvVar: "PLUGIN_CONTENT_TYPE",
+			Value:  &StringMapFlag{},
+		},
+		cli.GenericFlag{
+			Name:   "content-encoding",
+			Usage:  "content-encoding settings for uploads",
+			EnvVar: "PLUGIN_CONTENT_ENCODING",
+			Value:  &StringMapFlag{},
+		},
+		cli.GenericFlag{
+			Name:   "cache-control",
+			Usage:  "cache-control settings for uploads",
+			EnvVar: "PLUGIN_CACHE_CONTROL",
+			Value:  &StringMapFlag{},
+		},
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
@@ -103,19 +121,22 @@ func run(c *cli.Context) error {
 	}
 
 	plugin := Plugin{
-		Endpoint:    c.String("endpoint"),
-		Key:         c.String("access-key"),
-		Secret:      c.String("secret-key"),
-		Bucket:      c.String("bucket"),
-		Region:      c.String("region"),
-		Access:      c.String("acl"),
-		Source:      c.String("source"),
-		Target:      c.String("target"),
-		StripPrefix: c.String("strip-prefix"),
-		Exclude:     c.StringSlice("exclude"),
-		Encryption:  c.String("encryption"),
-		PathStyle:   c.Bool("path-style"),
-		DryRun:      c.Bool("dry-run"),
+		Endpoint:        c.String("endpoint"),
+		Key:             c.String("access-key"),
+		Secret:          c.String("secret-key"),
+		Bucket:          c.String("bucket"),
+		Region:          c.String("region"),
+		Access:          c.String("acl"),
+		Source:          c.String("source"),
+		Target:          c.String("target"),
+		StripPrefix:     c.String("strip-prefix"),
+		Exclude:         c.StringSlice("exclude"),
+		Encryption:      c.String("encryption"),
+		PathStyle:       c.Bool("path-style"),
+		CacheControl:    c.Generic("cache-control").(*StringMapFlag).Get(),
+		ContentType:     c.Generic("content-type").(*StringMapFlag).Get(),
+		ContentEncoding: c.Generic("content-encoding").(*StringMapFlag).Get(),
+		DryRun:          c.Bool("dry-run"),
 	}
 
 	return plugin.Exec()

--- a/matcher.go
+++ b/matcher.go
@@ -1,10 +1,11 @@
 package main
 
-import "regexp"
+import (
+	"regexp"
+)
 
 func matcher(match string, stringMap map[string]string) string {
 	for pattern := range stringMap {
-
 		matched, err := regexp.MatchString(pattern, match)
 
 		if err != nil {

--- a/matcher.go
+++ b/matcher.go
@@ -1,0 +1,20 @@
+package main
+
+import "regexp"
+
+func matcher(match string, stringMap map[string]string) string {
+	for pattern := range stringMap {
+
+		matched, err := regexp.MatchString(pattern, match)
+
+		if err != nil {
+			panic(err)
+		}
+
+		if matched {
+			return stringMap[pattern]
+		}
+	}
+
+	return ""
+}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+func TestMatcher(t *testing.T) {
+	match := "/data/css/file.cgz"
+
+	stringMap := make(map[string]string)
+	stringMap[".*(css|cgz)$"] = "text/css"
+
+	want := "text/css"
+	got := matcher(match, stringMap)
+
+	if got != want {
+		t.Errorf("matcher(%s, %v)\n\tgot: %q, want: %q", match, stringMap, got, want)
+	}
+}

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -15,3 +15,17 @@ func TestMatcher(t *testing.T) {
 		t.Errorf("matcher(%s, %v)\n\tgot: %q, want: %q", match, stringMap, got, want)
 	}
 }
+
+func TestMatcherEmpty(t *testing.T) {
+	match := "/data/css/file.cgz"
+
+	stringMap := make(map[string]string)
+	stringMap[""] = "text/css"
+
+	want := "text/css"
+	got := matcher(match, stringMap)
+
+	if got != want {
+		t.Errorf("matcher(%s, %v)\n\tgot: %q, want: %q", match, stringMap, got, want)
+	}
+}

--- a/plugin.go
+++ b/plugin.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"errors"
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -63,8 +62,6 @@ type Plugin struct {
 	// Strip the prefix from the target path
 	StripPrefix string
 
-	YamlVerified bool
-
 	// Exclude files matching this pattern.
 	Exclude []string
 
@@ -94,8 +91,6 @@ func (p *Plugin) Exec() error {
 	//Allowing to use the instance role or provide a key and secret
 	if p.Key != "" && p.Secret != "" {
 		conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
-	} else if p.YamlVerified != true {
-		return errors.New("Security issue: When using instance role you must have the yaml verified")
 	}
 	client := s3.New(session.New(), conf)
 

--- a/plugin.go
+++ b/plugin.go
@@ -103,9 +103,20 @@ func (p *Plugin) Exec() error {
 
 	// find the bucket
 	log.WithFields(log.Fields{
-		"region":   p.Region,
-		"endpoint": p.Endpoint,
-		"bucket":   p.Bucket,
+		"region":           p.Region,
+		"endpoint":         p.Endpoint,
+		"bucket":           p.Bucket,
+		"access":           p.Access,
+		"source":           p.Source,
+		"target":           p.Target,
+		"strip-prefix":     p.StripPrefix,
+		"exclude":          p.Exclude,
+		"path-style":       p.PathStyle,
+		"dry-run":          p.DryRun,
+		"content-type":     p.ContentType,
+		"content-encoding": p.ContentEncoding,
+		"cache-control":    p.CacheControl,
+		"metadata":         p.Metadata,
 	}).Info("Attempting to upload")
 
 	matches, err := matches(p.Source, p.Exclude)

--- a/plugin.go
+++ b/plugin.go
@@ -155,6 +155,7 @@ func (p *Plugin) Exec() error {
 
 		metadata := map[string]*string{}
 		for pattern := range p.Metadata {
+			// for compatibility with old 'glob' implementation
 			if matched, _ := regexp.MatchString(pattern, match); matched {
 				for k, v := range p.Metadata[pattern] {
 					metadata[k] = aws.String(v)

--- a/plugin.go
+++ b/plugin.go
@@ -192,18 +192,27 @@ func (p *Plugin) Exec() error {
 		defer f.Close()
 
 		putObjectInput := &s3.PutObjectInput{
-			Body:            f,
-			Bucket:          aws.String(p.Bucket),
-			Key:             aws.String(target),
-			ACL:             aws.String(p.Access),
-			ContentType:     aws.String(contentType),
-			ContentEncoding: aws.String(contentEncoding),
-			CacheControl:    aws.String(cacheControl),
-			Metadata:        metadata,
+			Body:     f,
+			Bucket:   aws.String(p.Bucket),
+			Key:      aws.String(target),
+			ACL:      aws.String(p.Access),
+			Metadata: metadata,
+		}
+
+		if contentType != "" {
+			putObjectInput.ContentType = aws.String(contentType)
+		}
+
+		if contentEncoding != "" {
+			putObjectInput.ContentEncoding = aws.String(contentEncoding)
+		}
+
+		if cacheControl != "" {
+			putObjectInput.CacheControl = aws.String(cacheControl)
 		}
 
 		if p.Encryption != "" {
-			putObjectInput.ServerSideEncryption = &(p.Encryption)
+			putObjectInput.ServerSideEncryption = aws.String(p.Encryption)
 		}
 
 		_, err = client.PutObject(putObjectInput)

--- a/plugin.go
+++ b/plugin.go
@@ -133,24 +133,22 @@ func (p *Plugin) Exec() error {
 			target = "/" + target
 		}
 
-		fileExt := filepath.Ext(match)
-
 		var contentType string
-		for patternExt := range p.ContentType {
-			if patternExt == fileExt {
-				contentType = p.ContentType[patternExt]
+		for pattern := range p.ContentType {
+			if glob.Glob(pattern, match) {
+				contentType = p.ContentType[pattern]
 				break
 			}
 		}
 
 		if contentType == "" {
-			contentType = mime.TypeByExtension(fileExt)
+			contentType = mime.TypeByExtension(filepath.Ext(match))
 		}
 
 		var contentEncoding string
-		for patternExt := range p.ContentEncoding {
-			if patternExt == fileExt {
-				contentEncoding = p.ContentEncoding[patternExt]
+		for pattern := range p.ContentEncoding {
+			if glob.Glob(pattern, match) {
+				contentEncoding = p.ContentEncoding[pattern]
 				break
 			}
 		}

--- a/types.go
+++ b/types.go
@@ -4,6 +4,34 @@ import (
 	"encoding/json"
 )
 
+type DeepStringMapFlag struct {
+	parts map[string]map[string]string
+}
+
+func (d *DeepStringMapFlag) String() string {
+	return ""
+}
+
+func (d *DeepStringMapFlag) Get() map[string]map[string]string {
+	return d.parts
+}
+
+func (d *DeepStringMapFlag) Set(value string) error {
+	d.parts = map[string]map[string]string{}
+	err := json.Unmarshal([]byte(value), &d.parts)
+	if err != nil {
+		single := map[string]string{}
+		err := json.Unmarshal([]byte(value), &single)
+		if err != nil {
+			return err
+		}
+
+		d.parts["*"] = single
+	}
+
+	return nil
+}
+
 type StringMapFlag struct {
 	parts map[string]string
 }

--- a/types.go
+++ b/types.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+type StringMapFlag struct {
+	parts map[string]string
+}
+
+func (s *StringMapFlag) String() string {
+	return ""
+}
+
+func (s *StringMapFlag) Get() map[string]string {
+	return s.parts
+}
+
+func (s *StringMapFlag) Set(value string) error {
+	s.parts = map[string]string{}
+	err := json.Unmarshal([]byte(value), &s.parts)
+	if err != nil {
+		s.parts["*"] = value
+	}
+	return nil
+}

--- a/types.go
+++ b/types.go
@@ -26,7 +26,7 @@ func (d *DeepStringMapFlag) Set(value string) error {
 			return err
 		}
 
-		d.parts["*"] = single
+		d.parts[""] = single
 	}
 
 	return nil
@@ -48,7 +48,7 @@ func (s *StringMapFlag) Set(value string) error {
 	s.parts = map[string]string{}
 	err := json.Unmarshal([]byte(value), &s.parts)
 	if err != nil {
-		s.parts["*"] = value
+		s.parts[""] = value
 	}
 	return nil
 }

--- a/vendor/github.com/ryanuber/go-glob/LICENSE
+++ b/vendor/github.com/ryanuber/go-glob/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ryan Uber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/ryanuber/go-glob/README.md
+++ b/vendor/github.com/ryanuber/go-glob/README.md
@@ -1,0 +1,29 @@
+# String globbing in golang [![Build Status](https://travis-ci.org/ryanuber/go-glob.svg)](https://travis-ci.org/ryanuber/go-glob)
+
+`go-glob` is a single-function library implementing basic string glob support.
+
+Globs are an extremely user-friendly way of supporting string matching without
+requiring knowledge of regular expressions or Go's particular regex engine. Most
+people understand that if you put a `*` character somewhere in a string, it is
+treated as a wildcard. Surprisingly, this functionality isn't found in Go's
+standard library, except for `path.Match`, which is intended to be used while
+comparing paths (not arbitrary strings), and contains specialized logic for this
+use case. A better solution might be a POSIX basic (non-ERE) regular expression
+engine for Go, which doesn't exist currently.
+
+Example
+=======
+
+```
+package main
+
+import "github.com/ryanuber/go-glob"
+
+func main() {
+    glob.Glob("*World!", "Hello, World!") // true
+    glob.Glob("Hello,*", "Hello, World!") // true
+    glob.Glob("*ello,*", "Hello, World!") // true
+    glob.Glob("World!", "Hello, World!")  // false
+    glob.Glob("/home/*", "/home/ryanuber/.bashrc") // true
+}
+```

--- a/vendor/github.com/ryanuber/go-glob/glob.go
+++ b/vendor/github.com/ryanuber/go-glob/glob.go
@@ -1,0 +1,56 @@
+package glob
+
+import "strings"
+
+// The character which is treated like a glob
+const GLOB = "*"
+
+// Glob will test a string pattern, potentially containing globs, against a
+// subject string. The result is a simple true/false, determining whether or
+// not the glob pattern matched the subject text.
+func Glob(pattern, subj string) bool {
+	// Empty pattern can only match empty subject
+	if pattern == "" {
+		return subj == pattern
+	}
+
+	// If the pattern _is_ a glob, it matches everything
+	if pattern == GLOB {
+		return true
+	}
+
+	parts := strings.Split(pattern, GLOB)
+
+	if len(parts) == 1 {
+		// No globs in pattern, so test for equality
+		return subj == pattern
+	}
+
+	leadingGlob := strings.HasPrefix(pattern, GLOB)
+	trailingGlob := strings.HasSuffix(pattern, GLOB)
+	end := len(parts) - 1
+
+	// Go over the leading parts and ensure they match.
+	for i := 0; i < end; i++ {
+		idx := strings.Index(subj, parts[i])
+
+		switch i {
+		case 0:
+			// Check the first section. Requires special handling.
+			if !leadingGlob && idx != 0 {
+				return false
+			}
+		default:
+			// Check that the middle parts match.
+			if idx < 0 {
+				return false
+			}
+		}
+
+		// Trim evaluated text from subj as we loop over the pattern.
+		subj = subj[idx+len(parts[i]):]
+	}
+
+	// Reached the last section. Requires special handling.
+	return trailingGlob || strings.HasSuffix(subj, parts[end])
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -191,6 +191,12 @@
 			"revisionTime": "2016-06-07T00:28:33Z"
 		},
 		{
+			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
+			"path": "github.com/ryanuber/go-glob",
+			"revision": "256dc444b735e061061cf46c809487313d5b0065",
+			"revisionTime": "2017-01-28T01:21:29Z"
+		},
+		{
 			"checksumSHA1": "W1G9Avuz92Ng1IqblcO/cIe6pHU=",
 			"path": "github.com/urfave/cli",
 			"revision": "d9021faab69f92295ef7061bd39e4a76dcbdef32",


### PR DESCRIPTION
As of Drone 0.7 the signed yaml verification is deprecated, so we shouldn't need to check for it when using IAM roles.