### PR TITLE
Adding CacheControl setting for S3 uploads

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,11 @@ func main() {
 			Usage:  "use path style for bucket paths",
 			EnvVar: "PLUGIN_PATH_STYLE",
 		},
+		cli.StringFlag{
+			Name:   "cache-control",
+			Usage:  "set cache-control header for uploaded objects",
+			EnvVar: "PLUGIN_CACHE_CONTROL",
+		},
 		cli.BoolTFlag{
 			Name:   "yaml-verified",
 			Usage:  "Ensure the yaml was signed",
@@ -119,6 +124,7 @@ func run(c *cli.Context) error {
 		StripPrefix:  c.String("strip-prefix"),
 		Exclude:      c.StringSlice("exclude"),
 		Encryption:   c.String("encryption"),
+		CacheControl: c.String("cache-control"),
 		PathStyle:    c.Bool("path-style"),
 		DryRun:       c.Bool("dry-run"),
 		YamlVerified: c.BoolT("yaml-verified"),

--- a/plugin.go
+++ b/plugin.go
@@ -48,6 +48,9 @@ type Plugin struct {
 	//     bucket-owner-full-control
 	Access string
 
+	// Sets the Cache-Control header on each uploaded object
+	CacheControl string
+
 	// Copies the files from the specified directory.
 	// Regexp matching will apply to match multiple
 	// files
@@ -169,6 +172,10 @@ func (p *Plugin) Exec() error {
 
 		if p.Encryption != "" {
 			putObjectInput.ServerSideEncryption = &(p.Encryption)
+		}
+
+		if p.CacheControl != "" {
+			putObjectInput.CacheControl = &(p.CacheControl)
 		}
 
 		_, err = client.PutObject(putObjectInput)


### PR DESCRIPTION
This is really useful if you're uploading S3 objects to eventually be served by a CDN, as CloudFront will respect this header when set on S3 objects.