### PR TITLE
Integrate content type and encoding maps

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,10 +89,23 @@ func main() {
 			Usage:  "use path style for bucket paths",
 			EnvVar: "PLUGIN_PATH_STYLE",
 		},
-		cli.StringFlag{
+		cli.GenericFlag{
+			Name:   "content-type",
+			Usage:  "set content type header for uploaded objects",
+			EnvVar: "PLUGIN_CONTENT_TYPE",
+			Value:  &StringMapFlag{},
+		},
+		cli.GenericFlag{
+			Name:   "content-encoding",
+			Usage:  "set content encoding header for uploaded objects",
+			EnvVar: "PLUGIN_CONTENT_ENCODING",
+			Value:  &StringMapFlag{},
+		},
+		cli.GenericFlag{
 			Name:   "cache-control",
 			Usage:  "set cache-control header for uploaded objects",
 			EnvVar: "PLUGIN_CACHE_CONTROL",
+			Value:  &StringMapFlag{},
 		},
 		cli.StringFlag{
 			Name:  "env-file",
@@ -111,20 +124,22 @@ func run(c *cli.Context) error {
 	}
 
 	plugin := Plugin{
-		Endpoint:     c.String("endpoint"),
-		Key:          c.String("access-key"),
-		Secret:       c.String("secret-key"),
-		Bucket:       c.String("bucket"),
-		Region:       c.String("region"),
-		Access:       c.String("acl"),
-		Source:       c.String("source"),
-		Target:       c.String("target"),
-		StripPrefix:  c.String("strip-prefix"),
-		Exclude:      c.StringSlice("exclude"),
-		Encryption:   c.String("encryption"),
-		CacheControl: c.String("cache-control"),
-		PathStyle:    c.Bool("path-style"),
-		DryRun:       c.Bool("dry-run"),
+		Endpoint:        c.String("endpoint"),
+		Key:             c.String("access-key"),
+		Secret:          c.String("secret-key"),
+		Bucket:          c.String("bucket"),
+		Region:          c.String("region"),
+		Access:          c.String("acl"),
+		Source:          c.String("source"),
+		Target:          c.String("target"),
+		StripPrefix:     c.String("strip-prefix"),
+		Exclude:         c.StringSlice("exclude"),
+		Encryption:      c.String("encryption"),
+		ContentType:     c.Generic("content-type").(*StringMapFlag).Get(),
+		ContentEncoding: c.Generic("content-encoding").(*StringMapFlag).Get(),
+		CacheControl:    c.Generic("cache-control").(*StringMapFlag).Get(),
+		PathStyle:       c.Bool("path-style"),
+		DryRun:          c.Bool("dry-run"),
 	}
 
 	return plugin.Exec()

--- a/stringmap.go
+++ b/stringmap.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"encoding/json"
+)
+
+type StringMapFlag struct {
+	parts map[string]string
+}
+
+func (s *StringMapFlag) String() string {
+	return ""
+}
+
+func (s *StringMapFlag) Get() map[string]string {
+	return s.parts
+}
+
+func (s *StringMapFlag) Set(value string) error {
+	s.parts = map[string]string{}
+
+	if err := json.Unmarshal([]byte(value), &s.parts); err != nil {
+		s.parts[".*"] = value
+	}
+
+	return nil
+}


### PR DESCRIPTION
To enforce specific content types and content encodings based on file
extensions I have taken more or less the code from the fork at
https://github.com/quintoandar/drone-s3 to integrate that functionality
directory into the official plugin.

Fixes https://github.com/drone-plugins/drone-s3/issues/54
Superseed https://github.com/drone-plugins/drone-s3/pull/34