### PR TITLE
Don't Specify an ACL by Default (Fixes #110)

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,6 @@ func main() {
 		cli.StringFlag{
 			Name:   "acl",
 			Usage:  "upload files with acl",
-			Value:  "private",
 			EnvVar: "PLUGIN_ACL",
 		},
 		cli.StringFlag{

--- a/plugin.go
+++ b/plugin.go
@@ -194,7 +194,6 @@ func (p *Plugin) Exec() error {
 			Body:   f,
 			Bucket: &(p.Bucket),
 			Key:    &target,
-			ACL:    &(p.Access),
 		}
 
 		if contentType != "" {
@@ -215,6 +214,10 @@ func (p *Plugin) Exec() error {
 
 		if p.StorageClass != "" {
 			putObjectInput.StorageClass = &(p.StorageClass)
+		}
+
+		if p.Access != "" {
+			putObjectInput.ACL = &(p.Access)
 		}
 
 		_, err = client.PutObject(putObjectInput)


### PR DESCRIPTION
ACLs in S3 predate IAM. They are also no longer recommended. Instead, users are encouraged to rely on IAM and Bucket Policies to manage access. Amazon is even going to start disabling ACLs on new buckets (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/ensure-object-ownership.html).Users are also generally encouraged to set `BucketOwnerEnforced` on existing buckets to disable ACLs.

When ACLs are disabled on a bucket, attempts to call `s3:PutObject` while specifying an `acl` parameter will cause an
`AccessControlListNotSupported` error from AWS specifying that `The bucket does not allow ACLs`.

This change updates the plugin so that there is no longer a default value for the ACL. The plugin will now only pass an ACL to `s3:PutObject` if one is explicitly specified by the user.

