### PR TITLE
Fix: assume user role ARN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,10 @@ _testmain.go
 *.test
 *.prof
 
+.idea/
 release/
 vendor/
 
 coverage.out
 drone-s3
+dockerfile


### PR DESCRIPTION
Hi,

I noticed my old pull request to implement support for assuming user role ARN been added to the master branch. But when testing the official release I found it not working. :)

session.NewSession(conf) needs to be called after the credentials been set, otherwise assume role will not work. 

Error given if access key/secret + user role arn is set:
NoCredentialProviders: no valid providers in chain.

I'm using this pull request change in my own AWS accounts, I have not tested simple credentials or the web identity (which needs own session to start with?).