### PR TITLE
fix: [CI-14134]: fix cross account access

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -99,7 +99,7 @@ type Plugin struct {
 	// set externalID for assume role
 	ExternalID string
 
-	// set OIDC ID Token to retrieve temporary credentials 
+	// set OIDC ID Token to retrieve temporary credentials
 	IdToken string
 }
 
@@ -434,55 +434,60 @@ func (p *Plugin) downloadS3Objects(client *s3.S3, sourceDir string) error {
 
 // createS3Client creates and returns an S3 client based on the plugin configuration
 func (p *Plugin) createS3Client() *s3.S3 {
-    conf := &aws.Config{
-        Region:           aws.String(p.Region),
-        Endpoint:         &p.Endpoint,
-        DisableSSL:       aws.Bool(strings.HasPrefix(p.Endpoint, "http://")),
-        S3ForcePathStyle: aws.Bool(p.PathStyle),
-    }
+	conf := &aws.Config{
+		Region:           aws.String(p.Region),
+		Endpoint:         &p.Endpoint,
+		DisableSSL:       aws.Bool(strings.HasPrefix(p.Endpoint, "http://")),
+		S3ForcePathStyle: aws.Bool(p.PathStyle),
+	}
 
-    sess, err := session.NewSession(conf)
-    if err != nil {
-        log.Fatalf("failed to create AWS session: %v", err)
-    }
+	sess, err := session.NewSession(conf)
+	if err != nil {
+		log.Fatalf("failed to create AWS session: %v", err)
+	}
 
-    if p.Key != "" && p.Secret != "" {
-        conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
-    } else if p.IdToken != "" && p.AssumeRole != "" {
-        creds, err := assumeRoleWithWebIdentity(sess, p.AssumeRole, p.AssumeRoleSessionName, p.IdToken)
-        if err != nil {
-            log.Fatalf("failed to assume role with web identity: %v", err)
-        }
-        conf.Credentials = creds
-    } else if p.AssumeRole != "" {
-        conf.Credentials = assumeRole(p.AssumeRole, p.AssumeRoleSessionName, p.ExternalID)
-    } else {
-        log.Warn("AWS Key and/or Secret not provided (falling back to ec2 instance profile)")
-    }
+	if p.Key != "" && p.Secret != "" {
+		conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
+	} else if p.IdToken != "" && p.AssumeRole != "" {
+		creds, err := assumeRoleWithWebIdentity(sess, p.AssumeRole, p.AssumeRoleSessionName, p.IdToken)
+		if err != nil {
+			log.Fatalf("failed to assume role with web identity: %v", err)
+		}
+		conf.Credentials = creds
+	} else if p.AssumeRole != "" {
+		conf.Credentials = assumeRole(p.AssumeRole, p.AssumeRoleSessionName, p.ExternalID)
+	} else {
+		log.Warn("AWS Key and/or Secret not provided (falling back to ec2 instance profile)")
+	}
 
-    client := s3.New(sess, conf)
+	sess, err = session.NewSession(conf)
+	if err != nil {
+		log.Fatalf("failed to create AWS session: %v", err)
+	}
 
-    if len(p.UserRoleArn) > 0 {
-        confRoleArn := aws.Config{
-            Region:      aws.String(p.Region),
-            Credentials: stscreds.NewCredentials(sess, p.UserRoleArn),
-        }
-        client = s3.New(sess, &confRoleArn)
-    }
+	client := s3.New(sess, conf)
 
-    return client
+	if len(p.UserRoleArn) > 0 {
+		confRoleArn := aws.Config{
+			Region:      aws.String(p.Region),
+			Credentials: stscreds.NewCredentials(sess, p.UserRoleArn),
+		}
+		client = s3.New(sess, &confRoleArn)
+	}
+
+	return client
 }
 
 func assumeRoleWithWebIdentity(sess *session.Session, roleArn, roleSessionName, idToken string) (*credentials.Credentials, error) {
-    svc := sts.New(sess)
-    input := &sts.AssumeRoleWithWebIdentityInput{
-        RoleArn:          aws.String(roleArn),
-        RoleSessionName:  aws.String(roleSessionName),
-        WebIdentityToken: aws.String(idToken),
-    }
-    result, err := svc.AssumeRoleWithWebIdentity(input)
-    if err != nil {
-        log.Fatalf("failed to assume role with web identity: %v", err)
-    }
-    return credentials.NewStaticCredentials(*result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken), nil
+	svc := sts.New(sess)
+	input := &sts.AssumeRoleWithWebIdentityInput{
+		RoleArn:          aws.String(roleArn),
+		RoleSessionName:  aws.String(roleSessionName),
+		WebIdentityToken: aws.String(idToken),
+	}
+	result, err := svc.AssumeRoleWithWebIdentity(input)
+	if err != nil {
+		log.Fatalf("failed to assume role with web identity: %v", err)
+	}
+	return credentials.NewStaticCredentials(*result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken), nil
 }

--- a/plugin.go
+++ b/plugin.go
@@ -99,7 +99,7 @@ type Plugin struct {
 	// set externalID for assume role
 	ExternalID string
 
-	// set OIDC ID Token to retrieve temporary credentials
+	// set OIDC ID Token to retrieve temporary credentials 
 	IdToken string
 }
 
@@ -434,60 +434,60 @@ func (p *Plugin) downloadS3Objects(client *s3.S3, sourceDir string) error {
 
 // createS3Client creates and returns an S3 client based on the plugin configuration
 func (p *Plugin) createS3Client() *s3.S3 {
-	conf := &aws.Config{
-		Region:           aws.String(p.Region),
-		Endpoint:         &p.Endpoint,
-		DisableSSL:       aws.Bool(strings.HasPrefix(p.Endpoint, "http://")),
-		S3ForcePathStyle: aws.Bool(p.PathStyle),
-	}
+    conf := &aws.Config{
+        Region:           aws.String(p.Region),
+        Endpoint:         &p.Endpoint,
+        DisableSSL:       aws.Bool(strings.HasPrefix(p.Endpoint, "http://")),
+        S3ForcePathStyle: aws.Bool(p.PathStyle),
+    }
 
-	sess, err := session.NewSession(conf)
-	if err != nil {
-		log.Fatalf("failed to create AWS session: %v", err)
-	}
+    sess, err := session.NewSession(conf)
+    if err != nil {
+        log.Fatalf("failed to create AWS session: %v", err)
+    }
 
-	if p.Key != "" && p.Secret != "" {
-		conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
-	} else if p.IdToken != "" && p.AssumeRole != "" {
-		creds, err := assumeRoleWithWebIdentity(sess, p.AssumeRole, p.AssumeRoleSessionName, p.IdToken)
-		if err != nil {
-			log.Fatalf("failed to assume role with web identity: %v", err)
-		}
-		conf.Credentials = creds
-	} else if p.AssumeRole != "" {
-		conf.Credentials = assumeRole(p.AssumeRole, p.AssumeRoleSessionName, p.ExternalID)
-	} else {
-		log.Warn("AWS Key and/or Secret not provided (falling back to ec2 instance profile)")
-	}
+    if p.Key != "" && p.Secret != "" {
+        conf.Credentials = credentials.NewStaticCredentials(p.Key, p.Secret, "")
+    } else if p.IdToken != "" && p.AssumeRole != "" {
+        creds, err := assumeRoleWithWebIdentity(sess, p.AssumeRole, p.AssumeRoleSessionName, p.IdToken)
+        if err != nil {
+            log.Fatalf("failed to assume role with web identity: %v", err)
+        }
+        conf.Credentials = creds
+    } else if p.AssumeRole != "" {
+        conf.Credentials = assumeRole(p.AssumeRole, p.AssumeRoleSessionName, p.ExternalID)
+    } else {
+        log.Warn("AWS Key and/or Secret not provided (falling back to ec2 instance profile)")
+    }
 
 	sess, err = session.NewSession(conf)
-	if err != nil {
-		log.Fatalf("failed to create AWS session: %v", err)
-	}
+    if err != nil {
+        log.Fatalf("failed to create AWS session: %v", err)
+    }
 
-	client := s3.New(sess, conf)
+    client := s3.New(sess, conf)
 
-	if len(p.UserRoleArn) > 0 {
-		confRoleArn := aws.Config{
-			Region:      aws.String(p.Region),
-			Credentials: stscreds.NewCredentials(sess, p.UserRoleArn),
-		}
-		client = s3.New(sess, &confRoleArn)
-	}
+    if len(p.UserRoleArn) > 0 {
+        confRoleArn := aws.Config{
+            Region:      aws.String(p.Region),
+            Credentials: stscreds.NewCredentials(sess, p.UserRoleArn),
+        }
+        client = s3.New(sess, &confRoleArn)
+    }
 
-	return client
+    return client
 }
 
 func assumeRoleWithWebIdentity(sess *session.Session, roleArn, roleSessionName, idToken string) (*credentials.Credentials, error) {
-	svc := sts.New(sess)
-	input := &sts.AssumeRoleWithWebIdentityInput{
-		RoleArn:          aws.String(roleArn),
-		RoleSessionName:  aws.String(roleSessionName),
-		WebIdentityToken: aws.String(idToken),
-	}
-	result, err := svc.AssumeRoleWithWebIdentity(input)
-	if err != nil {
-		log.Fatalf("failed to assume role with web identity: %v", err)
-	}
-	return credentials.NewStaticCredentials(*result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken), nil
+    svc := sts.New(sess)
+    input := &sts.AssumeRoleWithWebIdentityInput{
+        RoleArn:          aws.String(roleArn),
+        RoleSessionName:  aws.String(roleSessionName),
+        WebIdentityToken: aws.String(idToken),
+    }
+    result, err := svc.AssumeRoleWithWebIdentity(input)
+    if err != nil {
+        log.Fatalf("failed to assume role with web identity: %v", err)
+    }
+    return credentials.NewStaticCredentials(*result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken), nil
 }


### PR DESCRIPTION
changes made: we were creating session with config which does not had the credential info, added a code change to update a session with new cred info. Which will help cross account to authenticate .
Test the change with OIDC flow also. 

<img width="1719" alt="Screenshot 2024-09-19 at 1 13 43 AM" src="https://github.com/user-attachments/assets/0e9c3bc6-c1e4-4864-9bf5-b24e1c329fc4">
<img width="1204" alt="Screenshot 2024-09-19 at 1 14 01 AM" src="https://github.com/user-attachments/assets/991452dc-519f-458b-9b89-a9b5242a0bb3">
<img width="1199" alt="Screenshot 2024-09-19 at 1 14 40 AM" src="https://github.com/user-attachments/assets/bc000dd5-d3fa-4f2c-8497-113d1efd9fc0">
