### PR TITLE
feat: [CI-16855]: Fix S3 authentication to properly handle combined credential methods and role assumption

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -489,13 +489,7 @@ func (p *Plugin) createS3Client() *s3.S3 {
 		})
 
 		// Create new client with same config but updated credentials
-		client = s3.New(sess, &aws.Config{
-			Region:           aws.String(p.Region),
-			Endpoint:         &p.Endpoint,
-			DisableSSL:       aws.Bool(strings.HasPrefix(p.Endpoint, "http://")),
-			S3ForcePathStyle: aws.Bool(p.PathStyle),
-			Credentials:      creds,
-		})
+		client = s3.New(sess, &aws.Config{Credentials: creds})
 	}
 
 	return client


### PR DESCRIPTION
### Summary
The current implementation of the S3 client creation doesn't correctly handle scenarios where both primary credentials (access/secret keys, web identity, or initial role assumption) and secondary role assumption (via UserRoleArn) are used together. This causes authentication failures when users need to authenticate with one method and then assume a different role for S3 operations.

### Solution
Refactor `createS3Client` method to properly chain authentication methods:
1. First establish primary credentials (static credentials, web identity tokens, or initial role assumption)
2. Create an authenticated session with those credentials
3. If UserRoleArn is provided, use that authenticated session to assume the secondary role
4. Preserve all configuration options (endpoint, path style, region, etc.) when creating the final client

### Verification

The solution has been verified to work across all target environments:

IRSA Environment: [Successful execution](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/all/orgs/default/projects/devanshci/pipelines/s3uploadtestirsa_irsak8s/executions/9MpAme0kT1SDKE7_E2EoEQ/pipeline)
Regular Kubernetes: [Successful execution](https://app.harness.io/ng/account/B91tP-WFQKiWjJ_i0OoZ1g/module/cd/orgs/abhilabs/projects/labsproject/pipelines/opuploadpipline/executions/uGvyn9wdS2-fs0ZFdB60hg/pipeline?step=PlsTvaszQ9-95rrkxbl9nw&stage=iy1NEqdsRn-3NQfTStH3nA&childStage=&stageExecId=)
Cloud Build: [Successful execution](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/all/orgs/default/projects/devanshci/pipelines/s3uploadtestirsa_cloud/executions/iXEBb21hTGCTLzC8BjO5CA/pipeline)