### PR TITLE
feat: [CI-18487]: Glob pattern support for PLUGIN_STRIP_PREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,47 @@ docker run --rm \
   plugins/s3 --dry-run
 ```
 
+### Wildcard strip_prefix
+
+You can strip dynamic, runtime-generated directory prefixes from S3 keys using shell-style wildcards in `strip_prefix`.
+
+Supported patterns:
+
+- `*` matches exactly one path segment (no `/`).
+- `**` matches any depth (including zero segments).
+- `?` matches exactly one character (no `/`).
+
+The pattern is anchored at the start of the path. Use `/` to delimit directory boundaries. We recommend ending directory patterns with a trailing `/` to strip whole directory segments.
+
+Examples:
+
+- Pattern: `/harness/artifacts/*/`
+  - Path: `/harness/artifacts/build-123/module/app.zip`
+  - Result key suffix: `module/app.zip`
+
+- Pattern: `/harness/artifacts/**/`
+  - Path: `/harness/artifacts/build-123/deep/nested/file.zip`
+  - Result key suffix: `file.zip`
+
+- Pattern: `/harness/artifacts/*/services/`
+  - Path: `/harness/artifacts/build-123/services/auth/auth.zip`
+  - Result key suffix: `auth/auth.zip`
+
+Trailing slash semantics:
+
+- A trailing `/` indicates you are stripping up to a directory boundary.
+- Without a trailing `/`, the match may end mid-segment. For directory prefix stripping, prefer a trailing `/`.
+
+Windows notes:
+
+- `strip_prefix` must start with `/`. Backslashes are accepted and normalized to `/` internally (e.g. `\\harness\\artifacts\\*/` is allowed).
+- Windows drive letters like `C:\\...` are not supported and will be rejected.
+
+Dry-run logging:
+
+- With `--dry-run` or `PLUGIN_DRY_RUN=true`, the plugin logs what would be uploaded.
+- Fields include `name` (source), `target` (S3 key), `strip_pattern`, and `removed_prefix` (the portion stripped from the path when the pattern matches).
+
 * For Download
 ```
 docker run --rm \

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:   "strip-prefix",
-			Usage:  "used to add or remove a prefix from the source/target path",
+			Usage:  "prefix to strip from source path (supports wildcards: *, **, ?)",
 			EnvVar: "PLUGIN_STRIP_PREFIX",
 		},
 		cli.StringSliceFlag{

--- a/main.go
+++ b/main.go
@@ -163,7 +163,6 @@ func run(c *cli.Context) error {
 		_ = godotenv.Load(c.String("env-file"))
 	}
 
-
 	plugin := Plugin{
 		Endpoint:              c.String("endpoint"),
 		Key:                   c.String("access-key"),
@@ -193,4 +192,3 @@ func run(c *cli.Context) error {
 
 	return plugin.Exec()
 }
-

--- a/wildcard_strip_test.go
+++ b/wildcard_strip_test.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// ===============================
+// WILDCARD STRIP PREFIX TESTS
+// ===============================
+
+func TestStripWildcardPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		pattern     string
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		// Mandatory test cases from spec
+		{
+			name:     "Single wildcard - */",
+			path:     "/harness/artifacts/9f2c1b/module/app.zip",
+			pattern:  "/harness/artifacts/*/",
+			expected: "module/app.zip",
+		},
+		{
+			name:     "Double wildcard - */*/",
+			path:     "/harness/artifacts/hash/nightly/lib.zip",
+			pattern:  "/harness/artifacts/*/*/",
+			expected: "lib.zip",
+		},
+		{
+			name:     "Triple wildcard - */*/*/",
+			path:     "/harness/artifacts/a/b/c/doc.zip",
+			pattern:  "/harness/artifacts/*/*/*/",
+			expected: "doc.zip",
+		},
+		{
+			name:     "Any depth - **/",
+			path:     "/harness/artifacts/x/y/z/file.zip",
+			pattern:  "/harness/artifacts/**/",
+			expected: "file.zip",
+		},
+		{
+			name:     "No match - path unchanged",
+			path:     "/different/path/file.zip",
+			pattern:  "/harness/artifacts/*/",
+			expected: "/different/path/file.zip",
+		},
+		{
+			name:        "Empty key error",
+			path:        "/harness/artifacts/build/app.zip",
+			pattern:     "/harness/artifacts/build/app.zip",
+			expectError: true,
+			errorMsg:    "removes entire path",
+		},
+		{
+			name:     "Pattern with trailing content",
+			path:     "/harness/artifacts/build123/services/app.zip",
+			pattern:  "/harness/artifacts/*/services/",
+			expected: "app.zip",
+		},
+		{
+			name:     "Question mark wildcard",
+			path:     "/harness/artifacts/build1/app.zip",
+			pattern:  "/harness/artifacts/build?/",
+			expected: "app.zip",
+		},
+
+		// Additional edge cases
+		{
+			name:     "Literal prefix (no wildcards)",
+			path:     "/harness/artifacts/build/app.zip",
+			pattern:  "/harness/artifacts/",
+			expected: "build/app.zip",
+		},
+		{
+			name:     "Root wildcard",
+			path:     "/build/app.zip",
+			pattern:  "/*/",
+			expected: "app.zip",
+		},
+		{
+			name:     "Complex nested structure",
+			path:     "/harness/artifacts/build-123/services/auth/v1.2/auth-service.zip",
+			pattern:  "/harness/artifacts/*/services/*/",
+			expected: "v1.2/auth-service.zip",
+		},
+		{
+			name:     "Double asterisk with additional path",
+			path:     "/harness/artifacts/very/deep/nested/structure/file.zip",
+			pattern:  "/harness/artifacts/**/structure/",
+			expected: "file.zip",
+		},
+		{
+			name:     "Multiple question marks",
+			path:     "/harness/artifacts/build123/app.zip",
+			pattern:  "/harness/artifacts/build???/",
+			expected: "app.zip",
+		},
+		{
+			name:     "Empty pattern returns original path",
+			path:     "/harness/artifacts/build/app.zip",
+			pattern:  "",
+			expected: "/harness/artifacts/build/app.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := stripWildcardPrefix(tt.path, tt.pattern)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("stripWildcardPrefix(%q, %q) expected error, got nil", tt.path, tt.pattern)
+				} else if !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("stripWildcardPrefix(%q, %q) error = %v, want error containing %q", tt.path, tt.pattern, err, tt.errorMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("stripWildcardPrefix(%q, %q) unexpected error: %v", tt.path, tt.pattern, err)
+				} else if result != tt.expected {
+					t.Errorf("stripWildcardPrefix(%q, %q) = %q, want %q", tt.path, tt.pattern, result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestPatternToRegex(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		testPath string
+		matches  bool
+	}{
+		{
+			name:     "Single wildcard matches one segment",
+			pattern:  "/harness/artifacts/*/",
+			testPath: "/harness/artifacts/build123/",
+			matches:  true,
+		},
+		{
+			name:     "Single wildcard with exact match",
+			pattern:  "/harness/artifacts/*/",
+			testPath: "/harness/artifacts/build123/",
+			matches:  true,
+		},
+		{
+			name:     "Double wildcard matches any depth",
+			pattern:  "/harness/artifacts/**/",
+			testPath: "/harness/artifacts/build123/module1/deep/",
+			matches:  true,
+		},
+		{
+			name:     "Question mark matches single character",
+			pattern:  "/harness/artifacts/build?/",
+			testPath: "/harness/artifacts/build1/",
+			matches:  true,
+		},
+		{
+			name:     "Question mark doesn't match multiple characters",
+			pattern:  "/harness/artifacts/build?/",
+			testPath: "/harness/artifacts/build123/",
+			matches:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re, err := patternToRegex(tt.pattern)
+			if err != nil {
+				t.Fatalf("patternToRegex(%q) error: %v", tt.pattern, err)
+			}
+			
+			matches := re.MatchString(tt.testPath)
+			if matches != tt.matches {
+				t.Errorf("patternToRegex(%q).MatchString(%q) = %v, want %v", tt.pattern, tt.testPath, matches, tt.matches)
+			}
+		})
+	}
+}
+
+// ===============================
+// INTEGRATION TESTS - ResolveKey
+// ===============================
+
+func TestResolveKeyWithWildcards(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      string
+		srcPath     string
+		stripPrefix string
+		expected    string
+	}{
+		{
+			name:        "Informatica's scenario - single wildcard",
+			target:      "deployment",
+			srcPath:     "/harness/artifacts/build-123/module1/app.zip",
+			stripPrefix: "/harness/artifacts/*/",
+			expected:    "/deployment/module1/app.zip",
+		},
+		{
+			name:        "Deep nested with double wildcard",
+			target:      "releases",
+			srcPath:     "/harness/artifacts/build-456/services/auth/v1.0/auth-service.zip",
+			stripPrefix: "/harness/artifacts/**/services/",
+			expected:    "/releases/auth/v1.0/auth-service.zip",
+		},
+		{
+			name:        "Question mark pattern",
+			target:      "upload",
+			srcPath:     "/harness/artifacts/build1/app.zip",
+			stripPrefix: "/harness/artifacts/build?/",
+			expected:    "/upload/app.zip",
+		},
+		{
+			name:        "No wildcard - literal prefix",
+			target:      "backup",
+			srcPath:     "/harness/artifacts/build123/lib.zip",
+			stripPrefix: "/harness/artifacts/",
+			expected:    "/backup/build123/lib.zip",
+		},
+		{
+			name:        "Pattern doesn't match - path unchanged",
+			target:      "fallback",
+			srcPath:     "/different/location/file.zip",
+			stripPrefix: "/harness/artifacts/*/",
+			expected:    "/fallback/different/location/file.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolveKey(tt.target, tt.srcPath, tt.stripPrefix)
+			if result != tt.expected {
+				t.Errorf("resolveKey(%q, %q, %q) = %q, want %q", 
+					tt.target, tt.srcPath, tt.stripPrefix, result, tt.expected)
+			}
+		})
+	}
+}
+
+// ===============================
+// ERROR HANDLING TESTS  
+// ===============================
+
+func TestWildcardErrorHandling(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "Pattern doesn't start with slash",
+			pattern: "harness/artifacts/*/",
+			wantErr: true,
+			errMsg:  "must start with '/'",
+		},
+		{
+			name:    "Pattern too long (>256 chars)",
+			pattern: "/" + strings.Repeat("very-long-directory-name/", 15) + "*/", // >256 chars
+			wantErr: true,
+			errMsg:  "too long",
+		},
+		{
+			name:    "Too many wildcards (>20)",
+			pattern: "/" + strings.Repeat("*/", 21),
+			wantErr: true,
+			errMsg:  "too many wildcards",
+		},
+		{
+			name:    "Empty segment",
+			pattern: "/harness//artifacts/*/",
+			wantErr: true,
+			errMsg:  "empty segment",
+		},
+		{
+			name:    "Invalid ** usage",
+			pattern: "/harness/**artifacts/*/",
+			wantErr: true,
+			errMsg:  "standalone directory segment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateStripPrefix(tt.pattern)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateStripPrefix(%q) expected error, got nil", tt.pattern)
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("validateStripPrefix(%q) error = %v, want error containing %q", tt.pattern, err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateStripPrefix(%q) unexpected error: %v", tt.pattern, err)
+				}
+			}
+		})
+	}
+}
+
+// ===============================
+// PERFORMANCE BENCHMARK
+// ===============================
+
+func BenchmarkStripWildcardPrefix(b *testing.B) {
+	path := "/harness/artifacts/build-12345/services/auth/v1.2.3/auth-service.zip"
+	pattern := "/harness/artifacts/*/services/*/"
+	
+	// Pre-compile pattern (this would happen once in real usage)
+	_, err := patternToRegex(pattern)
+	if err != nil {
+		b.Fatalf("Failed to compile pattern: %v", err)
+	}
+	
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = stripWildcardPrefix(path, pattern)
+	}
+}

--- a/wildcard_strip_test.go
+++ b/wildcard_strip_test.go
@@ -111,7 +111,7 @@ func TestStripWildcardPrefix(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := stripWildcardPrefix(tt.path, tt.pattern)
-			
+
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("stripWildcardPrefix(%q, %q) expected error, got nil", tt.path, tt.pattern)
@@ -174,7 +174,7 @@ func TestPatternToRegex(t *testing.T) {
 			if err != nil {
 				t.Fatalf("patternToRegex(%q) error: %v", tt.pattern, err)
 			}
-			
+
 			matches := re.MatchString(tt.testPath)
 			if matches != tt.matches {
 				t.Errorf("patternToRegex(%q).MatchString(%q) = %v, want %v", tt.pattern, tt.testPath, matches, tt.matches)
@@ -236,7 +236,7 @@ func TestResolveKeyWithWildcards(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := resolveKey(tt.target, tt.srcPath, tt.stripPrefix)
 			if result != tt.expected {
-				t.Errorf("resolveKey(%q, %q, %q) = %q, want %q", 
+				t.Errorf("resolveKey(%q, %q, %q) = %q, want %q",
 					tt.target, tt.srcPath, tt.stripPrefix, result, tt.expected)
 			}
 		})
@@ -244,7 +244,7 @@ func TestResolveKeyWithWildcards(t *testing.T) {
 }
 
 // ===============================
-// ERROR HANDLING TESTS  
+// ERROR HANDLING TESTS
 // ===============================
 
 func TestWildcardErrorHandling(t *testing.T) {
@@ -311,13 +311,13 @@ func TestWildcardErrorHandling(t *testing.T) {
 func BenchmarkStripWildcardPrefix(b *testing.B) {
 	path := "/harness/artifacts/build-12345/services/auth/v1.2.3/auth-service.zip"
 	pattern := "/harness/artifacts/*/services/*/"
-	
+
 	// Pre-compile pattern (this would happen once in real usage)
 	_, err := patternToRegex(pattern)
 	if err != nil {
 		b.Fatalf("Failed to compile pattern: %v", err)
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = stripWildcardPrefix(path, pattern)

--- a/wildcard_strip_test.go
+++ b/wildcard_strip_test.go
@@ -310,39 +310,39 @@ func TestWildcardErrorHandling(t *testing.T) {
 // ===============================
 
 func TestWindowsBackslashInputs(t *testing.T) {
-    t.Run("validate single-backslash anchored pattern accepted", func(t *testing.T) {
-        if err := validateStripPrefix(`\harness\artifacts\*/`); err != nil {
-            t.Fatalf("validateStripPrefix backslash pattern unexpected error: %v", err)
-        }
-    })
+	t.Run("validate single-backslash anchored pattern accepted", func(t *testing.T) {
+		if err := validateStripPrefix(`\harness\artifacts\*/`); err != nil {
+			t.Fatalf("validateStripPrefix backslash pattern unexpected error: %v", err)
+		}
+	})
 
-    t.Run("reject UNC double-backslash pattern (empty segment)", func(t *testing.T) {
-        if err := validateStripPrefix(`\\harness\\artifacts\\*/`); err == nil {
-            t.Fatalf("expected error for UNC-style pattern, got nil")
-        }
-    })
+	t.Run("reject UNC double-backslash pattern (empty segment)", func(t *testing.T) {
+		if err := validateStripPrefix(`\\harness\\artifacts\\*/`); err == nil {
+			t.Fatalf("expected error for UNC-style pattern, got nil")
+		}
+	})
 
-    t.Run("reject drive-letter pattern", func(t *testing.T) {
-        if err := validateStripPrefix(`C:\\harness\\artifacts\\*/`); err == nil {
-            t.Fatalf("expected error for drive-letter pattern, got nil")
-        }
-    })
+	t.Run("reject drive-letter pattern", func(t *testing.T) {
+		if err := validateStripPrefix(`C:\\harness\\artifacts\\*/`); err == nil {
+			t.Fatalf("expected error for drive-letter pattern, got nil")
+		}
+	})
 }
 
 func TestExecStyleNormalizationWithWindowsPatterns(t *testing.T) {
-    // Ensure Windows-style strip_prefix works on forward-slash paths after normalization
-    patternWin := `\harness\artifacts\*/`
-    if err := validateStripPrefix(patternWin); err != nil {
-        t.Fatalf("validateStripPrefix(%q) error: %v", patternWin, err)
-    }
-    path := "/harness/artifacts/abc123/module/app.zip"
-    stripped, err := stripWildcardPrefix(path, patternWin)
-    if err != nil {
-        t.Fatalf("stripWildcardPrefix error: %v", err)
-    }
-    if want := "module/app.zip"; stripped != want {
-        t.Fatalf("stripped=%q want %q", stripped, want)
-    }
+	// Ensure Windows-style strip_prefix works on forward-slash paths after normalization
+	patternWin := `\harness\artifacts\*/`
+	if err := validateStripPrefix(patternWin); err != nil {
+		t.Fatalf("validateStripPrefix(%q) error: %v", patternWin, err)
+	}
+	path := "/harness/artifacts/abc123/module/app.zip"
+	stripped, err := stripWildcardPrefix(path, patternWin)
+	if err != nil {
+		t.Fatalf("stripWildcardPrefix error: %v", err)
+	}
+	if want := "module/app.zip"; stripped != want {
+		t.Fatalf("stripped=%q want %q", stripped, want)
+	}
 }
 
 // ===============================


### PR DESCRIPTION
<html><head></head><body>
<h3>Enhanced <code inline="">PLUGIN_STRIP_PREFIX</code> with Glob-Aware Wildcard Support</h3>
<p>This PR enhances the <code inline="">PLUGIN_STRIP_PREFIX</code> functionality by adding <strong>wildcard pattern support</strong>, allowing dynamic path stripping without relying on shell scripting. </p>
<hr>
<h3>Key Features</h3>
<ul>
<li>
<p><strong>Wildcard Patterns</strong>: Supports <code inline="">*</code>, <code inline="">**</code>, and <code inline="">?</code> for flexible path matching</p>
</li>
<li>
<p><strong>Backward Compatible</strong>: Existing literal path prefixes continue to work as-is</p>
</li>
<li>
<p><strong>Robust Validation</strong>: Comprehensive checks ensure invalid patterns are rejected gracefully</p>
</li>
<li>
<p>Added Unit Tests to test the working for all types of glob paths.</p>
</li>
</ul>
<hr>
<h3>🔧 Wildcard Syntax</h3>

Wildcard | Description | Regex Equivalent
-- | -- | --
\* | Matches exactly one path segment | [^/]+
** | Matches zero or more segments | .*
? | Matches exactly one character | [^/]

Testing Link: [url](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/all/orgs/default/projects/devanshci/pipelines/drones3CI18487/executions/wCnszf7-TyafYhh6QAjuTg/pipeline?step=duYM64M1RK-7B7eHELv4hw&stage=39SQvoAtRDKqPhiUuXopvg&childStage=&stageExecId=)
For the above testing correct directories were created:
<img width="673" height="540" alt="Screenshot 2025-08-11 at 2 22 05 PM" src="https://github.com/user-attachments/assets/69ab0b2c-16d2-4ef1-af45-3767e52462e4" />
<img width="620" height="589" alt="Screenshot 2025-08-11 at 2 22 22 PM" src="https://github.com/user-attachments/assets/de348d35-2cdc-4f48-8a85-373cb6ef1b10" />
<img width="641" height="589" alt="Screenshot 2025-08-11 at 2 22 53 PM" src="https://github.com/user-attachments/assets/9c216ec1-6d94-43c2-81ab-7584fc0d4ad1" />


</body></html>