### PR TITLE
fix: upgrade logrus to v1.9.3 to remediate CVE-2025-65637 (retry)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.48.0
 	github.com/joho/godotenv v1.4.0
 	github.com/mattn/go-zglob v0.0.4
-	github.com/sirupsen/logrus v1.9.0
+	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli v1.22.10
 )
 

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
-github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
## Security Fix: CVE-2025-65637 (HIGH) — logrus DoS Vulnerability

### Summary
This PR upgrades `github.com/sirupsen/logrus` from `v1.9.0` to `v1.9.3` to remediate CVE-2025-65637.

> Note: A previous fix PR (#216, branch `fix/cve-2025-65637-logrus-v1.9.3`) was opened on 2026-04-07 but was never merged into master. This PR reapplies the same fix targeting the current master branch.

---

### Patched CVEs

| CVE | Severity | Package | Old Version | Fixed Version | CVSS |
|-----|----------|---------|-------------|---------------|------|
| CVE-2025-65637 | HIGH | github.com/sirupsen/logrus | v1.9.0 | v1.9.3 | 8.7 |

**Description:** Denial-of-Service vulnerability in `logrus` `Entry.Writer()`. When processing single-line payloads exceeding 64KB without newline characters, `bufio.Scanner` fails with a "token too long" error, causing the writer pipe to close and the application to become unavailable.

**Advisory:** https://github.com/sirupsen/logrus/security/advisories

---

### Informational (no fix available)

| OSV ID | Severity | Package | Notes |
|--------|----------|---------|-------|
| GO-2022-0635 | UNKNOWN | aws-sdk-go v1.48.0 | No fix version available |
| GO-2022-0646 | UNKNOWN | aws-sdk-go v1.48.0 | No fix version available |

---

### Changes
- `go.mod`: `github.com/sirupsen/logrus` upgraded from `v1.9.0` to `v1.9.3`
- `go.sum`: regenerated via `go mod tidy`
- No Dockerfile present - no image changes required

### Tests
- OK `go test ./...` passed (`ok github.com/drone-plugins/drone-s3 0.004s`)

---
*Opened by Vigil Security Remediation Agent - 2026-04-08 18:31 UTC*