### PR TITLE
fix: [CI-22004]: Add static /bin/sh to scratch images for AWS SDK credential_process

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,5 +1,5 @@
 FROM alpine:3.17 as alpine
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates busybox-static
 
 FROM scratch
 
@@ -10,4 +10,8 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 ADD release/linux/amd64/drone-s3 /bin/
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# Static busybox installed as /bin/sh so the AWS SDK's credential_process
+# provider (which wraps commands in `sh -c`) and any other shell-based
+# invocations work inside this otherwise-scratch image.
+COPY --from=alpine /bin/busybox.static /bin/sh
 ENTRYPOINT ["/bin/drone-s3"]

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -10,8 +10,5 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
 
 ADD release/linux/amd64/drone-s3 /bin/
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-# Static busybox installed as /bin/sh so the AWS SDK's credential_process
-# provider (which wraps commands in `sh -c`) and any other shell-based
-# invocations work inside this otherwise-scratch image.
 COPY --from=alpine /bin/busybox.static /bin/sh
 ENTRYPOINT ["/bin/drone-s3"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -9,8 +9,5 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.schema-version="1.0"
 
 ADD release/linux/arm64/drone-s3 /bin/
-# Static busybox installed as /bin/sh so the AWS SDK's credential_process
-# provider (which wraps commands in `sh -c`) works inside this
-# otherwise-shell-less base image.
 COPY --from=alpine /bin/busybox.static /bin/sh
 ENTRYPOINT ["/bin/drone-s3"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,3 +1,6 @@
+FROM alpine:3.17 as alpine
+RUN apk add -U --no-cache busybox-static
+
 FROM plugins/base:multiarch
 
 LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
@@ -6,4 +9,8 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" \
   org.label-schema.schema-version="1.0"
 
 ADD release/linux/arm64/drone-s3 /bin/
+# Static busybox installed as /bin/sh so the AWS SDK's credential_process
+# provider (which wraps commands in `sh -c`) works inside this
+# otherwise-shell-less base image.
+COPY --from=alpine /bin/busybox.static /bin/sh
 ENTRYPOINT ["/bin/drone-s3"]


### PR DESCRIPTION
## Summary

Both Linux Dockerfiles for `drone-s3` produce images without a shell, which breaks AWS SDK Go v2's `credential_process` mechanism (and therefore the Harness AWS Credential Broker, AWS SSO process credentials, and any user-supplied `credential_process` binary) with:

```
process provider error: error in credential_process:
exec: "sh": executable file not found in $PATH
```

### Root cause

`aws-sdk-go-v2` `credentials/processcreds/provider.go` (`DefaultNewCommandBuilder.NewCommand`) wraps every `credential_process` invocation in `exec.Command("sh", "-c", <cmd>)` on non-Windows systems, so `/bin/sh` must exist inside the plugin container even when the `credential_process` value is a plain absolute path.

### Fix

Add an alpine builder stage that installs `busybox-static` and copy `/bin/busybox.static` into the final image as `/bin/sh`. Busybox is a multi-call binary that behaves as a POSIX sh when invoked via that name, satisfying the SDK's shell requirement. Adds ~1 MB per image.

- `docker/Dockerfile.linux.amd64`: previously `FROM scratch`; now also ships `/bin/sh`. No other behavioural change.
- `docker/Dockerfile.linux.arm64`: previously `FROM plugins/base:multiarch` (which is itself scratch-derived upstream and ships only CA certs and mime.types). Kept that base untouched so ca-certs, mime.types, `GODEBUG=netdns=go` and all labels continue to come from the same upstream image. Only added an alpine builder stage and a single `COPY --from=alpine /bin/busybox.static /bin/sh` line.

Windows Dockerfiles are intentionally left unchanged. AWS SDK Go v2 uses `cmd.exe /C` on Windows (`processcreds/provider.go` line 93-94), and `cmd.exe` is present in both `mcr.microsoft.com/windows/nanoserver` and in `plugins/base:windows-ltsc2022-amd64` (which is built from nanoserver), per Microsoft's container base image documentation.

No Go code, `go.mod`, `go.sum`, CI config, or plugin logic changes.

## Files changed

```
docker/Dockerfile.linux.amd64 | 6 +++++-
docker/Dockerfile.linux.arm64 | 9 ++++++++-
```

## Test plan

- [ ] Build both Linux images locally and verify `/bin/sh` exists and is executable (`docker run --rm --entrypoint /bin/sh <image> -c 'echo ok'`).
- [ ] Run drone-s3 in a Harness CI step with an AWS connector backed by `credential_process` (e.g. AWS Credential Broker) and confirm the upload succeeds instead of failing with the `exec: "sh"` error.
- [ ] Confirm image size delta is roughly +1 MB per arch.
- [ ] Verify CA certs / mime.types / existing labels on `linux.arm64` are unchanged (base image untouched).

Made with [Cursor](https://cursor.com)