### PR TITLE
feat: [CI-23717]: windows 2025 support

### DIFF
--- a/docker/Dockerfile.windows.ltsc2025
+++ b/docker/Dockerfile.windows.ltsc2025
@@ -1,0 +1,18 @@
+# escape=`
+
+# ---------------------------------------------------------------------------
+# drone-s3 for Windows Server 2025 (LTSC 2025)
+# ---------------------------------------------------------------------------
+
+FROM plugins/base:windows-ltsc2025-amd64
+USER ContainerAdministrator
+
+ENV GODEBUG=netdns=go
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone S3" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/drone-s3.exe C:/drone-s3.exe
+ENTRYPOINT [ "C:\\drone-s3.exe" ]

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -29,3 +29,9 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  -
+    image: plugins/s3:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2025-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025


### PR DESCRIPTION
This pull request adds support for Windows Server 2025 (LTSC 2025) to the Drone S3 plugin, ensuring compatibility with the latest Windows long-term servicing channel. The main changes include the addition of a new Dockerfile for the 2025 LTSC version and updating the Docker manifest to publish this new image variant.

**Windows Server 2025 support:**

* Added a new `Dockerfile.windows.ltsc2025` for building the Drone S3 plugin image targeting Windows Server 2025 (LTSC 2025).
* Updated `docker/manifest.tmpl` to include the `windows-ltsc2025-amd64` image in the multi-platform manifest, allowing automated publishing and discovery of the new variant.
<img width="1643" height="760" alt="Screenshot 2026-07-14 at 12 58 21 PM" src="https://github.com/user-attachments/assets/24b6a357-683b-4272-90ae-dfec2041d820" />
<img width="1389" height="223" alt="Screenshot 2026-07-14 at 12 58 27 PM" src="https://github.com/user-attachments/assets/42f33eca-c234-4766-9a13-abbcfd2152ce" />
